### PR TITLE
NetCommonsプラグイン側を elementにして Wysiwygプラグインで js指定を行う対応

### DIFF
--- a/View/Elements/wysiwyg_js.ctp
+++ b/View/Elements/wysiwyg_js.ctp
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Element of wysiwyg include
+ *
+ * @copyright Copyright 2014, NetCommons Project
+ * @author Satoru Majima <neo.otokomae@gmail.com>
+ * @link http://www.netcommons.org NetCommons Project
+ * @license http://www.netcommons.org/license.txt NetCommons License
+ */
+
+// wysiwyg呼び出し
+echo $this->NetCommonsHtml->script(
+	array(
+		'/wysiwyg/js/wysiwyg.js',
+		'/components/tinymce-dist/tinymce.min.js',
+		'/components/angular-ui-tinymce/src/tinymce.js',
+	)
+);


### PR DESCRIPTION
## Issues
#2 - Wysiwyg呼び出しストーリー
## 概要
- [ ] Wysiwygプラグイン側で element定義
- [ ] NetCommonsプラグインんは elementを呼び出す対応
