### PR TITLE
ファイル挿入 TinyMCEプラグイン製作

### DIFF
--- a/View/Elements/wysiwyg_js.ctp
+++ b/View/Elements/wysiwyg_js.ctp
@@ -14,8 +14,10 @@ echo $this->NetCommonsHtml->script(
 		'/components/tinymce-dist/tinymce.min.js',
 		'/components/angular-ui-tinymce/src/tinymce.js',
 		'/wysiwyg/js/wysiwyg.js',
+		'/wysiwyg/js/wysiwyg_app.js',
 		'/wysiwyg/js/plugins/tex/plugin.js',
 		'/wysiwyg/js/plugins/tex/iframe.js',
+		'/wysiwyg/js/plugins/file/plugin.js',
 		'/wysiwyg/js/plugins/nc3_preview/plugin.js',
 	)
 );

--- a/webroot/js/plugins/file/plugin.js
+++ b/webroot/js/plugins/file/plugin.js
@@ -1,0 +1,79 @@
+/**
+ * File - plugin
+ */
+// ad tinymce plugin
+tinymce.PluginManager.add('file', function(editor, url) {
+  //
+  var srcChange = function(e) {
+
+  };
+
+  var onSubmit = function() {
+
+  };
+
+  // ダイアログ表示
+  var showDialog = function() {
+    editor.windowManager.open({
+      title: 'File',
+      align: 'stretch',
+      padding: 10,
+      spacing: 10,
+      width: 400,
+      height: 100,
+      id: 'uploadForm',
+      body: [
+        {
+          name: 'src',
+          type: 'textbox',
+          subtype: 'file',
+          label: 'File',
+          name: 'uploadfile',
+          autofocus: true
+        }
+      ],
+      onsubmit: function(e) {
+        var src = e.data.uploadfile;
+        if (src) {
+          // formオブジェクト作成
+          var files = $('#uploadForm').find('input[type="file"]')[0].files[0];
+          var formData = new FormData();
+          formData.append('data[Wysiwyg][file]', files);
+          formData.append('data[Block][key]', 'block_1'); // ひとまずダミー送信
+
+          NC3_APP.uploadFile(formData,
+              function(res) {
+                // onsuccess
+                if (res.result) {
+                  editor.selection.collapse(true);
+                  editor.execCommand('mceInsertContent', false,
+                      editor.dom.createHTML('a',
+                          {
+                            href: res.file.path,
+                            target: '_brank'
+                          },
+                          res.file.original_name
+                      )
+                  );
+                } // if
+              },
+              function(res) {
+                // onerror
+              },
+              editor.settings.isDEBUG); // uploadfile()
+        } // if(src)
+      } // onsubmit
+    }); // open()
+  }; // showDialog
+
+  // コマンド登録
+  editor.addCommand('mceFile', showDialog);
+
+  // windowへのボタン登録
+  editor.addButton('file', {
+    text: 'File',
+    icon: false,
+    id: 'file-btn',
+    onclick: showDialog
+  });
+});

--- a/webroot/js/wysiwyg.js
+++ b/webroot/js/wysiwyg.js
@@ -20,7 +20,7 @@ NetCommonsApp.factory('NetCommonsWysiwyg', function() {
     mode: 'exact',
     menubar: false,
     plugins: 'advlist textcolor colorpicker table hr emoticons charmap ' +
-        'link media image code nc3Preview searchreplace paste tex',
+        'link media image code nc3Preview searchreplace paste tex file',
     toolbar: [
               'fontselect fontsizeselect formatselect ' +
               '| bold italic underline strikethrough ' +
@@ -29,7 +29,7 @@ NetCommonsApp.factory('NetCommonsWysiwyg', function() {
               'undo redo | alignleft aligncenter alignright ' +
               '| bullist numlist | outdent indent blockquote ' +
               '| table | hr | emoticons | tex | link unlink',
-              'media books image newdocument | pastetext code nc3Preview'
+              'media books image file | pastetext code nc3Preview'
     ],
     paste_as_text: true,
     setup: function(editor) {

--- a/webroot/js/wysiwyg_app.js
+++ b/webroot/js/wysiwyg_app.js
@@ -1,0 +1,132 @@
+/**
+ * nc3mce.app.js
+ * 共通処理クラス
+ */
+var NC3_APP = new (function nc3WysiwygApp() {
+  var self = this;
+  /**
+  * API URL設定
+  */
+  var __appURLs = (function() {
+    return {
+      uploadImage: function() {
+        return '/wysiwyg/image/upload';
+      },
+      uploadFile: function() {
+        return '/wysiwyg/file/upload';
+      }
+    };
+  })();
+  /////////////////////////////////////////////////
+  // Util
+  /////////////////////////////////////////////////
+  var JsonParse = function(data) {
+    var obj = data;
+    try {
+      if (typeof data == 'string') {
+        obj = JSON.parse(data);
+      }
+    } catch (e) {
+      obj = {};
+      // console.log('Error JSON.parse(data) : ' + e.message);
+    }
+    return obj;
+  };
+  var toJson = function(data) {
+    var obj = data;
+    try {
+      if (typeof data == 'object' || typeof data == 'array') {
+        obj = JSON.stringify(data);
+      }
+    } catch (e) {
+      obj = {};
+      // console.log('Error JSON.stringify(data) : ' + e.message);
+    }
+    return obj;
+  };
+  /////////////////////////////////////////////////
+  // httpリクエスト
+  /////////////////////////////////////////////////
+  var __httpReq = function(method, url, formData, onsuccess, onerror, name) {
+    $.ajax({
+      type: method.toLowerCase(),
+      url: url,
+      data: formData,
+      crossDomain: true,
+      cache: false,
+      processData: false, // Ajaxがdataを整形しない指定
+      contentType: false  // contentTypeもfalseに指定
+
+    }).done(function(data, success, xobj) {
+      var obj = JsonParse(data);
+      $.isFunction(onsuccess) && onsuccess(obj);
+      $.Deferred().resolve();
+
+    }).fail(function(data, textStatus, errorThrown) {
+      $.isFunction(onerror) && onsuccess(onerror);
+    });
+  };
+  /////////////////////////////////////////////////
+  // API(formDataを使用)
+  /////////////////////////////////////////////////
+  /**
+  * トークンの確認(TODO)
+  */
+  var __checkToken = function() {
+
+  };
+  /**
+  * 画像のアップロード
+  */
+  self.uploadImage = function(formData, onsuccess, onerr, isDEBUG) {
+    if (isDEBUG) {
+      onsuccess();
+      return false;
+    }
+    var url = __appURLs.uploadImage();
+    __httpReq(
+        'post',
+        url,
+        formData,
+        onsuccess,
+        onerror,
+        'uploadImage'
+    );
+  };
+  /**
+  * ファイルのアップロード
+  */
+  self.uploadFile = function(formData, onsuccess, onerr, isDEBUG) {
+    if (isDEBUG) {
+      onsuccess(DUMMY_DATA.upload_file);
+      return false;
+    }
+    var url = __appURLs.uploadFile();
+    __httpReq(
+        'post',
+        url,
+        formData,
+        onsuccess,
+        onerror,
+        'uploadFile'
+    );
+  };
+})();
+
+
+var DUMMY_DATA = {
+  upload_file: {
+    status_code: 200,
+    result: true,
+    file: {
+      id: 0001,
+      original_name: 'ファイル名',
+      path: ''
+    }
+  },
+  upload_file_false: {
+    status_code: 401,
+    result: false,
+    message: 'エラー'
+  }
+};


### PR DESCRIPTION
## issues
#17 - ファイルアップロード
#11 - 添付ファイルのリンクの挿入
## 機能・タスク
- [x] アップロードファイル選択ダイアログの表示
- [x] ファイルのアップロード処理（CakePHP側の呼び出し）
- [x] アップロード後の WYSIWYG内への挿入
## 現状の課題点
- CakePHPの upload先URLの指定 /wysiwyg/file/upload をハードコードしている
- data[Block][key] はどこの値を取りに行けばいいか指定が可能か（現在ダミー送信）
- ファイル挿入するも WYSIWYG内で相対パスに変換されるのを防ぐ
