### PR TITLE
スマートフォン表示対応

### DIFF
--- a/View/Helper/WysiwygHelper.php
+++ b/View/Helper/WysiwygHelper.php
@@ -10,6 +10,8 @@
  */
 
 App::uses('AppHelper', 'View/Helper');
+App::uses('ComponentCollection', 'Controller');
+App::uses('MobileDetectComponent', 'MobileDetect.Controller/Component');
 
 /**
  * WysiwygHelper
@@ -28,6 +30,20 @@ class WysiwygHelper extends AppHelper {
 		'NetCommons.NetCommonsHtml',
 		'NetCommons.TitleIcon',
 	);
+
+	/** MobileDetectコンポーネント定義 */
+	protected $_mobileDetect;
+
+/**
+ * Constructor
+ *
+ * @param View $view The View this helper is being attached to.
+ * @param array $settings Configuration settings for the helper.
+ */
+	public function __construct(View $view, $settings = array()) {
+		parent::__construct($view, $settings);
+		$this->mobileDetect = new MobileDetectComponent(new ComponentCollection());
+	}
 
 /**
  * WYSIWYGの初期処理
@@ -99,6 +115,9 @@ class WysiwygHelper extends AppHelper {
 			// ファイル・画像アップロードパス
 			'file_upload_path' => $this->NetCommonsHtml->url('/wysiwyg/file/upload'),
 			'image_upload_path' => $this->NetCommonsHtml->url('/wysiwyg/image/upload'),
+
+			// mobile判別
+			'is_mobile' => $this->mobileDetect->detect('isMobile'),
 		];
 
 		// constsnts 設定を JavaScriptで利用するための設定に変換する

--- a/View/Helper/WysiwygHelper.php
+++ b/View/Helper/WysiwygHelper.php
@@ -10,8 +10,6 @@
  */
 
 App::uses('AppHelper', 'View/Helper');
-App::uses('ComponentCollection', 'Controller');
-App::uses('MobileDetectComponent', 'MobileDetect.Controller/Component');
 
 /**
  * WysiwygHelper
@@ -30,20 +28,6 @@ class WysiwygHelper extends AppHelper {
 		'NetCommons.NetCommonsHtml',
 		'NetCommons.TitleIcon',
 	);
-
-	/** MobileDetectコンポーネント定義 */
-	protected $_mobileDetect;
-
-/**
- * Constructor
- *
- * @param View $view The View this helper is being attached to.
- * @param array $settings Configuration settings for the helper.
- */
-	public function __construct(View $view, $settings = array()) {
-		parent::__construct($view, $settings);
-		$this->_mobileDetect = new MobileDetectComponent(new ComponentCollection());
-	}
 
 /**
  * WYSIWYGの初期処理
@@ -117,7 +101,7 @@ class WysiwygHelper extends AppHelper {
 			'image_upload_path' => $this->NetCommonsHtml->url('/wysiwyg/image/upload'),
 
 			// mobile判別
-			'is_mobile' => $this->_mobileDetect->detect('isMobile'),
+			'is_mobile' => Configure::read('isMobile'),
 		];
 
 		// constsnts 設定を JavaScriptで利用するための設定に変換する

--- a/View/Helper/WysiwygHelper.php
+++ b/View/Helper/WysiwygHelper.php
@@ -42,7 +42,7 @@ class WysiwygHelper extends AppHelper {
  */
 	public function __construct(View $view, $settings = array()) {
 		parent::__construct($view, $settings);
-		$this->mobileDetect = new MobileDetectComponent(new ComponentCollection());
+		$this->_mobileDetect = new MobileDetectComponent(new ComponentCollection());
 	}
 
 /**
@@ -117,7 +117,7 @@ class WysiwygHelper extends AppHelper {
 			'image_upload_path' => $this->NetCommonsHtml->url('/wysiwyg/image/upload'),
 
 			// mobile判別
-			'is_mobile' => $this->mobileDetect->detect('isMobile'),
+			'is_mobile' => $this->_mobileDetect->detect('isMobile'),
 		];
 
 		// constsnts 設定を JavaScriptで利用するための設定に変換する

--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -151,3 +151,100 @@ div.wysiwyg-books {
 .wysiwyg-clearfix {
     min-height: 1px;
 }
+
+/**
+ * スマホ用表示
+ * プラグインでのopen()時のclasses:'sp-dialog'の設定が必要
+ * mediaクエリを使用しない場合は.wysiwyg-sp-viewを先頭に置き、
+ */
+/** max-device-width: 667pxは6s基準 */
+@media only screen and (max-device-width: 667px) {
+    #mce-modal-block {
+    }
+    .mce-window {
+        width: auto !important;
+        top: 0 !important;
+        left: 0 !important;
+        right: 0 !important;
+        bottom: 0 !important;
+        background: none !important;
+    }
+    .mce-window-head {
+        background: #fff !important;
+    }
+    .mce-window-body {
+        background: #fff !important;
+    }
+    .mce-foot {
+    }
+    .mce-foot > .mce-container-body {
+        padding: 10px !important;
+    }
+    .mce-foot button {
+    }
+    .mce-foot .mce-abs-layout{
+        text-align: right;
+    }
+    .mce-foot .mce-abs-layout-item.mce-btn {
+        display: inline-block;
+    }
+    .mce-foot .mce-abs-layout-item.mce-btn:last-child {
+        margin-right: 20px !important;
+    }
+    .mce-panel {
+        max-width: 100% !important;
+    }
+    .mce-container {
+        max-width: 100% !important;
+        height: auto !important;
+    }
+    .mce-container-body {
+        max-width: 100% !important;
+        height: auto !important;
+    }
+    .mce-form {
+        padding: 10px !important;
+    }
+    .mce-tabs {
+        max-width: 100% !important;
+    }
+    .mce-formitem {
+        margin: 10px 0 !important;
+    }
+    .mce-abs-layout-item {
+        position: static !important;
+        width: auto !important;
+    }
+    .mce-abs-layout-item.mce-label {
+        display: block !important;
+    }
+    .mce-abs-layout-item.mce-textbox {
+        -webkit-box-sizing: border-box !important;
+        -moz-box-sizing: border-box !important;
+        box-sizing: border-box !important;
+        display: block !important;
+        width: 100% !important;
+    }
+    .mce-abs-layout-item.mce-combobox {
+        display: flex !important;
+    }
+    .mce-abs-layout-item.mce-combobox > .mce-textbox {
+        -ms-flex: 1 1 auto;
+        -webkit-flex: 1 1 auto;
+        flex: 1 1 auto;
+        height: 29px !important;
+    }
+
+    /** 書籍検索 */
+    .mce-sp-dialog#wysiwyg-books-search.mce-container {
+        max-width: 100% !important;
+        height: 500px !important;
+    }
+    #wysiwyg-books-search-body.mce-container-body {
+        max-width: 100% !important;
+        height: 500px !important;
+    }
+    #wysiwyg-books-result.mce-container {
+        height: 300px !important;
+    }
+}

--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -1,3 +1,8 @@
+
+#tinymce {
+    margin: 6px 12px;
+}
+
 #wysiwyg-book-search {
     font-size: 0.9em;
 }
@@ -38,7 +43,7 @@ div.wysiwyg-books {
     white-space: normal;
 }
 .wysiwyg-books .book-title a, .wysiwyg-books .book-title span {
-	font-size: 1.2em;
+    font-size: 1.2em;
     color: #337ab7;
     text-decoration: none;
     white-space: normal;

--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -3,13 +3,12 @@
     margin: 6px 12px;
 }
 
-#wysiwyg-book-search {
-    font-size: 0.9em;
-}
-
 /**
  * ダイアログ表示の補正(書籍検索)
  */
+#wysiwyg-book-search {
+    font-size: 0.9em;
+}
 #wysiwyg-books-result {
     position:relative;
     width:100%;
@@ -159,97 +158,98 @@ div.wysiwyg-books {
 
 /**
  * スマホ用表示
- * プラグインでのopen()時のclasses:'sp-dialog'の設定が必要
- * mediaクエリを使用しない場合は.wysiwyg-sp-viewを先頭に置き、
+ * NC3側からもらえるis_mobileの値がtrueの時bodyに"wysiwyg-sp-view"クラスを付与するので
+ * ダイアログに関連するスタイルを.wysiwyg-sp-viewセレクタから記述する
  */
-/** max-device-width: 667pxは6s基準 */
-@media only screen and (max-device-width: 667px) {
-    #mce-modal-block {
-    }
-    .mce-window {
-        width: auto !important;
-        top: 0 !important;
-        left: 0 !important;
-        right: 0 !important;
-        bottom: 0 !important;
-        background: none !important;
-    }
-    .mce-window-head {
-        background: #fff !important;
-    }
-    .mce-window-body {
-        background: #fff !important;
-    }
-    .mce-foot {
-    }
-    .mce-foot > .mce-container-body {
-        padding: 10px !important;
-    }
-    .mce-foot button {
-    }
-    .mce-foot .mce-abs-layout{
-        text-align: right;
-    }
-    .mce-foot .mce-abs-layout-item.mce-btn {
-        display: inline-block;
-    }
-    .mce-foot .mce-abs-layout-item.mce-btn:last-child {
-        margin-right: 20px !important;
-    }
-    .mce-panel {
-        max-width: 100% !important;
-    }
-    .mce-container {
-        max-width: 100% !important;
-        height: auto !important;
-    }
-    .mce-container-body {
-        max-width: 100% !important;
-        height: auto !important;
-    }
-    .mce-form {
-        padding: 10px !important;
-    }
-    .mce-tabs {
-        max-width: 100% !important;
-    }
-    .mce-formitem {
-        margin: 10px 0 !important;
-    }
-    .mce-abs-layout-item {
-        position: static !important;
-        width: auto !important;
-    }
-    .mce-abs-layout-item.mce-label {
-        display: block !important;
-    }
-    .mce-abs-layout-item.mce-textbox {
-        -webkit-box-sizing: border-box !important;
-        -moz-box-sizing: border-box !important;
-        box-sizing: border-box !important;
-        display: block !important;
-        width: 100% !important;
-    }
-    .mce-abs-layout-item.mce-combobox {
-        display: flex !important;
-    }
-    .mce-abs-layout-item.mce-combobox > .mce-textbox {
-        -ms-flex: 1 1 auto;
-        -webkit-flex: 1 1 auto;
-        flex: 1 1 auto;
-        height: 29px !important;
-    }
+.wysiwyg-sp-view .mce-floatpanel {
+    overflow-y: scroll;
+}
+.wysiwyg-sp-view #mce-modal-block {
+}
+.wysiwyg-sp-view .mce-window {
+    width: auto !important;
+    top: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    background: none !important;
+}
+.wysiwyg-sp-view .mce-window-head {
+    background: #fff !important;
+}
+.wysiwyg-sp-view .mce-window-body {
+    background: #fff !important;
+}
+.wysiwyg-sp-view .mce-foot {
+}
+.wysiwyg-sp-view .mce-foot > .mce-container-body {
+    padding: 10px !important;
+}
+.wysiwyg-sp-view .mce-foot button {
+}
+.wysiwyg-sp-view .mce-foot .mce-abs-layout{
+    text-align: right;
+}
+.wysiwyg-sp-view .mce-foot .mce-abs-layout-item.mce-btn {
+    display: inline-block;
+}
+.wysiwyg-sp-view .mce-foot .mce-abs-layout-item.mce-btn:last-child {
+    margin-right: 20px !important;
+}
+.wysiwyg-sp-view .mce-panel {
+    max-width: 100% !important;
+}
+.wysiwyg-sp-view .mce-container {
+    max-width: 100% !important;
+    height: auto !important;
+}
+.wysiwyg-sp-view .mce-container-body {
+    width: 100% !important;
+    max-width: 100% !important;
+    height: auto !important;
+}
+.wysiwyg-sp-view .mce-form {
+    padding: 10px !important;
+}
+.wysiwyg-sp-view .mce-tabs {
+    max-width: 100% !important;
+}
+.wysiwyg-sp-view .mce-formitem {
+    margin: 10px 0 !important;
+}
+.wysiwyg-sp-view .mce-abs-layout-item {
+    position: static !important;
+    width: auto !important;
+}
+.wysiwyg-sp-view .mce-abs-layout-item.mce-label {
+    display: block !important;
+}
+.wysiwyg-sp-view .mce-abs-layout-item.mce-textbox {
+    -webkit-box-sizing: border-box !important;
+    -moz-box-sizing: border-box !important;
+    box-sizing: border-box !important;
+    display: block !important;
+    width: 100% !important;
+}
+.wysiwyg-sp-view .mce-abs-layout-item.mce-combobox {
+    display: flex !important;
+}
+.wysiwyg-sp-view .mce-abs-layout-item.mce-combobox > .mce-textbox {
+    -ms-flex: 1 1 auto;
+    -webkit-flex: 1 1 auto;
+    flex: 1 1 auto;
+    height: 29px !important;
+}
 
-    /** 書籍検索 */
-    .mce-sp-dialog#wysiwyg-books-search.mce-container {
-        max-width: 100% !important;
-        height: 500px !important;
-    }
-    #wysiwyg-books-search-body.mce-container-body {
-        max-width: 100% !important;
-        height: 500px !important;
-    }
-    #wysiwyg-books-result.mce-container {
-        height: 300px !important;
-    }
+/** 書籍検索 */
+.wysiwyg-sp-view .mce-sp-dialog#wysiwyg-books-search.mce-container {
+    max-width: 100% !important;
+    height: 500px !important;
+}
+.wysiwyg-sp-view #wysiwyg-books-search-body.mce-container-body {
+    max-width: 100% !important;
+    height: 500px !important;
+}
+.wysiwyg-sp-view #wysiwyg-books-result.mce-container {
+    height: 300px !important;
 }

--- a/webroot/js/wysiwyg.js
+++ b/webroot/js/wysiwyg.js
@@ -30,6 +30,22 @@ NetCommonsApp.factory('NetCommonsWysiwyg', function(nc3Configs,
         return colors;
       };
 
+      var toolbarPc = [
+        'fontselect fontsizeselect formatselect ' +
+            '| bold italic underline strikethrough ' +
+            '| subscript superscript | forecolor backcolor ' +
+            '| removeformat' +
+            '| undo redo | alignleft aligncenter alignright ' +
+            '| bullist numlist | indent outdent blockquote ' +
+            '| table | hr | titleicons | tex | link unlink' +
+            '| media booksearch nc3Image file | pastetext code nc3Preview'
+      ];
+      var toolbarMobile = [
+        'styleselect forecolor backcolor titleicons nc3Image mybutton'
+      ];
+
+      var toolbar = nc3Configs.is_mobile ? toolbarMobile : toolbarPc;
+
       /**
        * tinymce optins
        *
@@ -41,16 +57,7 @@ NetCommonsApp.factory('NetCommonsWysiwyg', function(nc3Configs,
         plugins: 'advlist nc3_textcolor colorpicker table hr titleicons ' +
             'charmap link media nc3Image code nc3Preview searchreplace ' +
             'paste tex file booksearch',
-        toolbar: [
-                  'fontselect fontsizeselect formatselect ' +
-                  '| bold italic underline strikethrough ' +
-                  '| subscript superscript | forecolor backcolor ' +
-                  '| removeformat' +
-                  '| undo redo | alignleft aligncenter alignright ' +
-                  '| bullist numlist | indent outdent blockquote ' +
-                  '| table | hr | titleicons | tex | link unlink' +
-                  '| media booksearch nc3Image file | pastetext code nc3Preview'
-        ],
+        toolbar: toolbar,
 
         font_formats: 'ゴシック=Arial, Roboto, “Droid Sans”, ' +
                       '“游ゴシック”, "Yu Gothic", "YuGothic", ' +

--- a/webroot/js/wysiwyg_app.js
+++ b/webroot/js/wysiwyg_app.js
@@ -5,6 +5,20 @@
 var NC3_APP = new (function nc3WysiwygApp() {
   var self = this;
   /**
+   * モバイル表示用判定
+   */
+  self.isSpView = false;
+  $(window).on('resize orientationchange', function() {
+    var flg = tinymce.editors[0].settings.nc3Configs.is_mobile;
+    self.isSpView = flg;
+    if (flg) {
+      $('body').addClass('wysiwyg-sp-view');
+    } else {
+      $('body').removeClass('wysiwyg-sp-view');
+    }
+  });
+  $(window).trigger('resize');
+  /**
   * API URL設定
   */
   var __appURLs = (function() {
@@ -52,6 +66,28 @@ var NC3_APP = new (function nc3WysiwygApp() {
     }
     return obj;
   };
+  // 画面の向き取得
+  var currentO, defaultO, timer = false;
+  self.checkOrientation = function() {
+    if ('orientation' in window) {
+      var o = (window.orientation % 180 == 0);
+      if ((o && defaultO) || !(o || defaultO)) {
+        currentO = 'portrait';
+      }
+      else {
+        currentO = 'landscape';
+      }
+    }
+    return currentO;
+  };
+  if ('orientation' in window) {
+    var o1 = (window.innerWidth < window.innerHeight);
+    var o2 = (window.orientation % 180 == 0);
+    defaultO = (o1 && o2) || !(o1 || o2);
+    beforeO = defaultO;
+    self.checkOrientation();
+  }
+
   /////////////////////////////////////////////////
   // httpリクエスト
   /////////////////////////////////////////////////


### PR DESCRIPTION
- [x] ツールバーのスマホ表示対応
- [x] WYSIWYGの表示するダイアログがスマホの画面に収まるための対応
## Issues
#44
## 機能

スマホでも問題なく WYSIWYGが使用できるための対応
### ツールバー表示
- フォントプルダウン
- 色
- 絵文字
- 画像
### ダイアログを納める対応
- スマホ表示でダイアログが収まらないプラグインの洗い出し
- CSS の変更で対応できるかの確認
- CSS で出来ない場合は各プラグインで対応
