### PR TITLE
Fix not to remove the script tag if user has authority

### DIFF
--- a/View/Helper/WysiwygHelper.php
+++ b/View/Helper/WysiwygHelper.php
@@ -134,8 +134,13 @@ class WysiwygHelper extends AppHelper {
 			'is_mobile' => Configure::read('isMobile'),
 		];
 
-		// constsnts 設定を JavaScriptで利用するための設定に変換する
-		//
+		// 許可するタグの設定
+		if (Current::permission('html_not_limited')) {
+			$constants['extended_valid_elements'] = 'script[src|title|type]';
+			$constants['cleanup'] = false;
+		}
+
+		// constants 設定を JavaScriptで利用するための設定に変換する
 		$this->NetCommonsHtml->scriptStart(array('inline' => false));
 		echo "NetCommonsApp.service('nc3Configs', function() {";
 			foreach ($constants as $key => $value) {

--- a/webroot/js/wysiwyg.js
+++ b/webroot/js/wysiwyg.js
@@ -92,7 +92,11 @@ NetCommonsApp.factory('NetCommonsWysiwyg',
 
           // 言語設定
           language: nc3Configs.lang,
-          language_url: nc3Configs.lang_js
+          language_url: nc3Configs.lang_js,
+
+          // 許可するタグの設定
+          extended_valid_elements: nc3Configs.extended_valid_elements,
+          cleanup: nc3Configs.cleanup
         };
 
         /**


### PR DESCRIPTION
tinymceがscriptタグを除去してしまうため、HTMLタグを許可する権限の場合にtinymceの設定を変更して削除されないように修正

また、tinymceの仕様により、

```
<p>aaa<script type="text/javascript">
window.alert("Hello!!");
</script>bbb</p>
```

のような記述は

```
<p>aaa
<script type="text/javascript">// <![CDATA[
window.alert("Hello!!");
// ]]></script>
bbb</p>
```

のようにCDATAで囲われることになる。
