### PR TITLE
Wysiwygでjavascriptを許可しているにもかかわらず、scriptが消される。 #605 の修正

### DIFF
--- a/Model/Behavior/PurifiableBehavior.php
+++ b/Model/Behavior/PurifiableBehavior.php
@@ -44,10 +44,6 @@ class PurifiableBehavior extends ModelBehavior {
 			'Core' => array(
 				'Encoding' => 'UTF-8'
 			),
-			'AutoFormat' => array(
-				'RemoveSpansWithoutAttributes' => true,
-				'RemoveEmpty' => true
-			),
 		),
 		'customFilters' => array(
 		)

--- a/Test/Case/Model/Behavior/PurifiableBehavior/HtmlLimitedTest.php
+++ b/Test/Case/Model/Behavior/PurifiableBehavior/HtmlLimitedTest.php
@@ -139,7 +139,7 @@ class HtmlLimitedTest extends NetCommonsCakeTestCase {
 		$content = '<iframe src="http://www.example.com/" width="560" height="314"></iframe>';
 		$data[$this->__modelName]['content'] = $content;
 		$result = $FakeModel->save($data);
-		$this->assertEquals('', $result[$this->__modelName]['content']);
+		$this->assertEquals('<iframe width="560" height="314"></iframe>', $result[$this->__modelName]['content']);
 	}
 
 /**


### PR DESCRIPTION
中身が空のタグを除去する設定が残っていたことが原因。
