### PR TITLE
Wysiwygで画像を編集時に画像のサイズを変更できるように対応 

### DIFF
--- a/webroot/js/plugins/nc3_image/plugin.js
+++ b/webroot/js/plugins/nc3_image/plugin.js
@@ -136,6 +136,7 @@ tinymce.PluginManager.add('nc3Image', function(editor, url) {
     $el.attr('alt', d.alt_edit);
     $el.attr('data-size', d.size_edit);
     $el.attr('src', imgSrc);
+    $el.attr('data-mce-src', imgSrc);
     $el.attr('data-position', d.position_edit);
     $el.attr('class', ''); // クラス初期化
     $el.attr('class', vals.img_elm_class + ' ' +


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/730

``` js
$el.attr('data-mce-src', imgSrc);
```

HTMLを確認したところ、`data-mce-src`が変わらず残っていましたので、上書きするように1行加えて、直りました。
おおよそtinymceの独自な値と思うので、この対応で大丈夫かと思います。

問題なければ、マージおねがいします。
