### PR TITLE
phpunit4以降でno testsのエラーが発生するため、abstract classに修正

### DIFF
--- a/TestSuite/WysiwygControllerTestCase.php
+++ b/TestSuite/WysiwygControllerTestCase.php
@@ -20,7 +20,7 @@ App::uses('NetCommonsControllerTestCase', 'NetCommons.TestSuite');
  * @package NetCommons\Wysiwyg\TestSuite
  * @codeCoverageIgnore
  */
-class WysiwygControllerTestCase extends NetCommonsControllerTestCase {
+abstract class WysiwygControllerTestCase extends NetCommonsControllerTestCase {
 
 /**
  * Fixtures

--- a/TestSuite/WysiwygHelperTestCase.php
+++ b/TestSuite/WysiwygHelperTestCase.php
@@ -20,7 +20,7 @@ App::uses('NetCommonsHelperTestCase', 'NetCommons.TestSuite');
  * @package NetCommons\Wysiwyg\TestSuite
  * @codeCoverageIgnore
  */
-class WysiwygHelperTestCase extends NetCommonsHelperTestCase {
+abstract class WysiwygHelperTestCase extends NetCommonsHelperTestCase {
 
 /**
  * Fixtures

--- a/TestSuite/WysiwygModelTestCase.php
+++ b/TestSuite/WysiwygModelTestCase.php
@@ -20,7 +20,7 @@ App::uses('NetCommonsModelTestCase', 'NetCommons.TestSuite');
  * @package NetCommons\Wysiwyg\TestSuite
  * @codeCoverageIgnore
  */
-class WysiwygModelTestCase extends NetCommonsModelTestCase {
+abstract class WysiwygModelTestCase extends NetCommonsModelTestCase {
 
 /**
  * Fixtures


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/998