### PR TITLE
WysiwygでPCの時に横に広げれるようにする

### DIFF
--- a/webroot/js/wysiwyg.js
+++ b/webroot/js/wysiwyg.js
@@ -78,6 +78,7 @@ NetCommonsApp.factory('NetCommonsWysiwyg',
 
           paste_as_text: true,
           convert_urls: false,
+          resize: 'both',
           content_css: nc3Configs.content_css,
 
           nc3Configs: nc3Configs,


### PR DESCRIPTION
 https://github.com/NetCommons3/NetCommons3/issues/1102

問題なさそうなら、1、２日でマージしようと思っています。

### 動作確認しました。
PCでは横に広げる事も可能
スマートフォン（iPhone）では下のみ広げる事を確認