### PR TITLE
fix: iframeの許可するURLがyoutubeのみで自サイトの動画プラグインが許可されていないため修正

### DIFF
--- a/Model/Behavior/PurifiableBehavior.php
+++ b/Model/Behavior/PurifiableBehavior.php
@@ -10,6 +10,7 @@
  */
 
 App::uses('Current', 'NetCommons.Utility');
+App::uses('NetCommonsUrl', 'NetCommons.Utility');
 App::uses('UserRole', 'UserRoles.Model');
 App::uses('HTMLPurifier_Filter_Comment', 'Wysiwyg.Utility/Filter');
 
@@ -162,7 +163,11 @@ class PurifiableBehavior extends ModelBehavior {
 				'Trusted' => true,
 			),
 			'URI' => array(
-				'SafeIframeRegexp' => '%^(https?:)?//(www\.youtube(?:-nocookie)?\.com/)%',
+				'SafeIframeRegexp' => '%(' .
+					'^(https?:)?//(www\.youtube(?:-nocookie)?\.com/)' .
+					'|' .
+					'^' . preg_quote(NetCommonsUrl::actionUrl('/videos/videos/embed/', true), '%') .
+				')%',
 			),
 			'Output' => array(
 				'FlashCompat' => true,


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1572