### PR TITLE
fix: 動画サムネイルやWysiwygの画像を直リンクした際に拒否IPアドレスチェック漏れ

### DIFF
--- a/Controller/WysiwygImageDownloadController.php
+++ b/Controller/WysiwygImageDownloadController.php
@@ -81,7 +81,6 @@ class WysiwygImageDownloadController extends Controller {
 		if (! (new NetCommonsSecurity())->enableBadIps()) {
 			throw new NotFoundException();
 		}
-
 		// シンプルにしたかったためAppModelを利用。インスタンス生成時少し速かった。
 		/* @var $Room AppModel */
 		$Room = ClassRegistry::init('Room');
@@ -162,10 +161,9 @@ class WysiwygImageDownloadController extends Controller {
 		ClassRegistry::removeObject('RolesRoomsUser');
 		ClassRegistry::removeObject('RoomRolePermissions');
 
-		$options = ['field' => 'Wysiwyg.file'];
-
 		// サイズ指定があるときにサイズ指定を行う。
 		// 指定がなければオリジナルサイズ
+		$options = ['field' => 'Wysiwyg.file'];
 		if (!empty($size)) {
 			// 指定したサイズが UploadFileモデル指定以外のサイズの時は 404 Not Found.
 			if (array_key_exists($size, $this->_getThumbnailSizes()) === false) {
@@ -173,7 +171,6 @@ class WysiwygImageDownloadController extends Controller {
 			}
 			$options['size'] = $size;
 		}
-
 		return $this->Download->doDownloadByUploadFileId($id, $options);
 	}
 

--- a/Controller/WysiwygImageDownloadController.php
+++ b/Controller/WysiwygImageDownloadController.php
@@ -11,6 +11,7 @@
 App::uses('Controller', 'Controller');
 App::uses('AuthComponent', 'Controller/Component');
 App::uses('AppModel', 'Model');
+App::uses('NetCommonsSecurity', 'NetCommons.Utility');
 
 /**
  * WysiwygImageDownloadController
@@ -77,6 +78,10 @@ class WysiwygImageDownloadController extends Controller {
 		if (is_null($roomId) || is_null($id)) {
 			throw new NotFoundException();
 		}
+		if (! (new NetCommonsSecurity())->enableBadIps()) {
+			throw new NotFoundException();
+		}
+
 		// シンプルにしたかったためAppModelを利用。インスタンス生成時少し速かった。
 		/* @var $Room AppModel */
 		$Room = ClassRegistry::init('Room');


### PR DESCRIPTION
(コンテンツ自体はエラーになるため問題なし)
https://github.com/NetCommons3/NetCommons3/issues/1668